### PR TITLE
Make examples more robust and informative

### DIFF
--- a/pynest/examples/eprop_plasticity/eprop_supervised_classification.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_classification.py
@@ -94,7 +94,7 @@ try:
     from IPython.display import Image
 
     Image(filename="./eprop_supervised_regression_infrastructure.png")
-except:
+except Exception:
     pass
 
 # %% ###########################################################################################################

--- a/pynest/examples/eprop_plasticity/eprop_supervised_classification.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_classification.py
@@ -81,7 +81,6 @@ import matplotlib.pyplot as plt
 import nest
 import numpy as np
 from cycler import cycler
-from IPython.display import Image
 
 # %% ###########################################################################################################
 # Schematic of network architecture
@@ -90,7 +89,13 @@ from IPython.display import Image
 # the input and output of the pattern generation task above, and lists of the required NEST device, neuron, and
 # synapse models below. The connections that must be established are numbered 1 to 7.
 
-Image(filename="./eprop_supervised_classification_infrastructure.png")
+try:
+    # Display image in IPython or notebook if available
+    from IPython.display import Image
+
+    Image(filename="./eprop_supervised_regression_infrastructure.png")
+except:
+    pass
 
 # %% ###########################################################################################################
 # Setup
@@ -585,7 +590,7 @@ recall_errors = 1.0 - accuracy
 # Furthermore, we compare the calculated losses to some hardcoded verification losses to ensure everything with
 # the NEST installation is fine. For the unmodified script, these should be precisely the same.
 
-loss_verification = [
+loss_reference = [
     0.7411525500061912,
     0.7403881877007442,
     0.6657852331777671,
@@ -593,10 +598,18 @@ loss_verification = [
     0.7294289628449472,
 ]
 
-if loss.tolist()[:5] == loss_verification:
-    print("\n verification successful \n")
+if np.allclose(loss[:5], loss_reference, rtol=1e-8):
+    print()
+    print("Verification successful.")
+    print()
 else:
-    print("\n verification FAILED ! \n")
+    print()
+    print("Verification FAILED!")
+    print(f"    Expected  : {loss_reference}")
+    print(f"    Observed  : {loss[:5]}")
+    print(f"    Difference: {loss_reference-loss[:5]}")
+    print()
+    exit(1)
 
 # %% ###########################################################################################################
 # Plot results

--- a/pynest/examples/eprop_plasticity/eprop_supervised_regression.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_regression.py
@@ -90,7 +90,7 @@ try:
     from IPython.display import Image
 
     Image(filename="./eprop_supervised_regression_infrastructure.png")
-except:
+except Exception:
     pass
 
 # %% ###########################################################################################################

--- a/pynest/examples/eprop_plasticity/eprop_supervised_regression.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_regression.py
@@ -77,7 +77,6 @@ import matplotlib.pyplot as plt
 import nest
 import numpy as np
 from cycler import cycler
-from IPython.display import Image
 
 # %% ###########################################################################################################
 # Schematic of network architecture
@@ -86,7 +85,13 @@ from IPython.display import Image
 # the input and output of the pattern generation task above, and lists of the required NEST device, neuron, and
 # synapse models below. The connections that must be established are numbered 1 to 6.
 
-Image(filename="./eprop_supervised_regression_infrastructure.png")
+try:
+    # Display image in IPython or notebook if available
+    from IPython.display import Image
+
+    Image(filename="./eprop_supervised_regression_infrastructure.png")
+except:
+    pass
 
 # %% ###########################################################################################################
 # Setup
@@ -469,12 +474,20 @@ loss = 0.5 * np.add.reduceat(error, np.arange(0, steps["task"], steps["sequence"
 # Furthermore, we compare the calculated losses to some hardcoded verification losses to ensure everything with
 # the NEST installation is fine. For the unmodified script, these should be precisely the same.
 
-loss_verification = [101.96435699904158, 103.4667311262058, 103.34060707477168, 103.68024403768639, 104.41277574875247]
+loss_reference = [101.96435699904158, 103.46673112620580, 103.34060707477168, 103.68024403768639, 104.41277574875247]
 
-if loss.tolist()[:5] == loss_verification:
-    print("\n verification successful \n")
+if np.allclose(loss[:5], loss_reference, rtol=1e-8):
+    print()
+    print("Verification successful.")
+    print()
 else:
-    print("\n verification FAILED ! \n")
+    print()
+    print("Verification FAILED!")
+    print(f"    Expected  : {loss_reference}")
+    print(f"    Observed  : {loss[:5]}")
+    print(f"    Difference: {loss_reference-loss[:5]}")
+    print()
+    exit(1)
 
 # %% ###########################################################################################################
 # Plot results


### PR DESCRIPTION
@akorgor Now a PR against the right repo ... With the example from the pynest/examples directory, everything works :). This PR makes the examples more robust and informative. First, the `IPython` import and the `Image` call are protected with a `try`, which is essential for automated running of the examples. Second, I changed the verification test to also use `np.allclose()`, to print out information on failure, and to call `exit(1)` in that case. For automated checking of examples, it is important to return a non-zero exit code if the example failed.

In `np.allclose()`, I used `rtol`. I suggest you do that in the pytests as well. Given that floating-point numerics always work on 53 bits multiplied with some exponent, relative error is the most sensible quantity to look for, except when the expected value is zero, when on needs to use `atol`. 